### PR TITLE
feat: add Langtrace API key configuration for LLM observability

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,7 +16,8 @@ import 'services/tracking.dart';
 /// flutter build web \
 ///   --dart-define=SENTRY_DSN=your-dsn \
 ///   --dart-define=ENVIRONMENT=production \
-///   --dart-define=APP_VERSION=2.0.0
+///   --dart-define=APP_VERSION=2.0.0 \
+///   --dart-define=LANGTRACE_API_KEY=your-langtrace-api-key
 /// ```
 abstract final class SentryConfig {
   /// Sentry DSN (Data Source Name) for error reporting.
@@ -42,6 +43,21 @@ abstract final class SentryConfig {
 
   /// Percentage of transactions to profile.
   static const profilesSampleRate = 0.2;
+}
+
+/// Langtrace configuration for Claude Code subscription-based API key.
+///
+/// Langtrace provides observability for LLM applications.
+/// Configure via compile-time environment variable:
+/// ```bash
+/// flutter build web --dart-define=LANGTRACE_API_KEY=your-api-key
+/// ```
+abstract final class LantraceConfig {
+  /// Langtrace API key for LLM observability.
+  static const apiKey = String.fromEnvironment('LANGTRACE_API_KEY');
+
+  /// Whether Langtrace is configured (API key is provided).
+  static bool get isConfigured => apiKey.isNotEmpty;
 }
 
 // =============================================================================


### PR DESCRIPTION
Add LantraceConfig class to support Claude Code subscription-based API key via compile-time environment variable (LANGTRACE_API_KEY).