### PR TITLE
fix(stripe-webhook): set organizations.active_subscription_id

### DIFF
--- a/workers/lib/billing.ts
+++ b/workers/lib/billing.ts
@@ -63,3 +63,20 @@ export function toBillingStatus(stripeStatus: string): BillingStatus {
 export function isEntitled(status: BillingStatus): boolean {
   return status === 'active' || status === 'trialing';
 }
+
+/**
+ * Whether a subscription has reached a state it can never leave.
+ *
+ * Used to decide when `organizations.active_subscription_id` should be cleared. Note this
+ * is deliberately *not* the inverse of `isEntitled`: `past_due`, `unpaid`, `paused` and
+ * `incomplete` are all unentitled but still describe a live subscription the org owns, so
+ * the org should keep pointing at it. Only `canceled` and `incomplete_expired` are
+ * terminal — Stripe never transitions out of either.
+ *
+ * Keeping this beside `isEntitled` for the same reason that one exists: the tempting
+ * shorthand (`!isEntitled(status)`) reads as obviously correct and would orphan the
+ * pointer the moment a payment failed.
+ */
+export function isTerminalSubscriptionStatus(status: string): boolean {
+  return status === 'canceled' || status === 'incomplete_expired';
+}

--- a/workers/stripe-webhook/src/supabase.test.ts
+++ b/workers/stripe-webhook/src/supabase.test.ts
@@ -254,12 +254,19 @@ describe('upsertSubscription', () => {
     db = makeAdmin();
   });
 
-  /** Soft-delete step succeeds by default; callers override the POST route. */
+  /**
+   * Soft-delete step succeeds by default; callers override the POST route.
+   *
+   * The `PATCH organizations` route is required, not incidental: upsertSubscription
+   * writes back `organizations.active_subscription_id` after the upsert, so omitting it
+   * makes every case fail on the write-back rather than on what it means to test.
+   */
   const subscriptionRoutes = (
     overrides: Record<string, RouteResponder> = {},
   ): Record<string, RouteResponder> => ({
     [`PATCH ${SUBSCRIPTIONS_TABLE}`]: updatedRows([]),
     [`POST ${SUBSCRIPTIONS_TABLE}`]: createdRows([{ id: 'sub-row-1' }]),
+    [`PATCH ${ORGANIZATIONS_TABLE}`]: updatedRows([{ id: 'org-1' }]),
     ...overrides,
   });
 
@@ -285,6 +292,64 @@ describe('upsertSubscription', () => {
         status: 'active',
       }),
     ]);
+  });
+
+  // Nothing wrote organizations.active_subscription_id before 2026-08-01 — not this
+  // Worker, not api-gateway, not any DB trigger — so the FK sat null even for paying
+  // orgs. team-inventoryai-io was observed with a live subscription row and a null
+  // pointer, which is what surfaced it.
+  it('points the org at the upserted subscription row', async () => {
+    const stub = stubSupabase(subscriptionRoutes());
+
+    const result = await db.upsertSubscription('org-1', 'sub_abc', 'price_xyz', 'active');
+
+    expect(result).toEqual({ ok: true });
+    const patch = stub.find('PATCH', ORGANIZATIONS_TABLE)!;
+    expect(objectBody(patch)).toEqual(
+      expect.objectContaining({ active_subscription_id: 'sub-row-1' }),
+    );
+    expect(patch.url.searchParams.get('id')).toBe('eq.org-1');
+  });
+
+  // Deliberately not `!isEntitled(status)`: past_due is unentitled but still describes a
+  // live subscription the org owns, so the pointer must survive a failed payment.
+  it.each(['past_due', 'unpaid', 'paused', 'incomplete', 'trialing'])(
+    'keeps the pointer set for non-terminal status %s',
+    async (status) => {
+      const stub = stubSupabase(subscriptionRoutes());
+
+      await db.upsertSubscription('org-1', 'sub_abc', 'price_xyz', status);
+
+      const patch = stub.find('PATCH', ORGANIZATIONS_TABLE)!;
+      expect(objectBody(patch)).toEqual(
+        expect.objectContaining({ active_subscription_id: 'sub-row-1' }),
+      );
+    },
+  );
+
+  it.each(['canceled', 'incomplete_expired'])(
+    'clears the pointer for terminal status %s',
+    async (status) => {
+      const stub = stubSupabase(subscriptionRoutes());
+
+      await db.upsertSubscription('org-1', 'sub_abc', 'price_xyz', status);
+
+      const patch = stub.find('PATCH', ORGANIZATIONS_TABLE)!;
+      expect(objectBody(patch)).toEqual(
+        expect.objectContaining({ active_subscription_id: null }),
+      );
+    },
+  );
+
+  it('reports failure when the org write-back fails', async () => {
+    const stub = stubSupabase(
+      subscriptionRoutes({ [`PATCH ${ORGANIZATIONS_TABLE}`]: () => new Response('boom', { status: 500 }) }),
+    );
+
+    const result = await db.upsertSubscription('org-1', 'sub_abc', 'price_xyz', 'active');
+
+    expect(result.ok).toBe(false);
+    expect(stub.find('POST', SUBSCRIPTIONS_TABLE)).toBeDefined();
   });
 
   it('stamps created_at and updated_at with the same timestamp as the soft-delete', async () => {

--- a/workers/stripe-webhook/src/supabase.ts
+++ b/workers/stripe-webhook/src/supabase.ts
@@ -1,6 +1,23 @@
 import { createSupabaseClient } from '../../lib/supabase';
+import { isTerminalSubscriptionStatus } from '../../lib/billing';
 import type { BillingStatus, ApiKeyTier } from '../../lib/types';
 import { DEAD_LETTER_INITIAL_RETRY_DELAY_MS, DEAD_LETTER_MAX_RETRIES } from '../../constants';
+
+/**
+ * Shape passed to and returned from the `subscriptions` upsert. `id` is absent on insert
+ * (Postgres generates it) and present in the response, since the client requests
+ * `return=representation` — that returned id is what populates
+ * `organizations.active_subscription_id`.
+ */
+interface SubscriptionUpsertRow extends Record<string, unknown> {
+  id?: string;
+  organization_id: string;
+  stripe_subscription_id: string;
+  stripe_price_id: string | null;
+  status: string;
+  created_at: string;
+  updated_at: string;
+}
 
 /**
  * Projection of the `webhook_dead_letters` row used by fetchPendingDeadLetters.
@@ -83,7 +100,9 @@ export function createSupabaseAdmin(supabaseUrl: string, serviceRoleKey: string)
     if (!cancelResult.ok) {
       return { ok: false, error: cancelResult.error };
     }
-    const result = await sb.upsert(
+    // `id` is optional on the way in (Postgres generates it) but present on the way back,
+    // because the client upserts with `return=representation`.
+    const result = await sb.upsert<SubscriptionUpsertRow>(
       'subscriptions',
       {
         organization_id: orgId,
@@ -95,7 +114,32 @@ export function createSupabaseAdmin(supabaseUrl: string, serviceRoleKey: string)
       },
       'organization_id',
     );
-    return toVoidResult(result);
+    if (!result.ok) {
+      return toVoidResult(result);
+    }
+
+    // Point the org at its current subscription row. Nothing wrote
+    // `organizations.active_subscription_id` before 2026-08-01 — not this Worker, not
+    // api-gateway, not any DB trigger — so the FK sat permanently null even for paying
+    // orgs, and `team-inventoryai-io` was observed with a live subscription row and a
+    // null pointer. Doing it here rather than per-handler covers all three writers
+    // (checkout.session.completed, customer.subscription.updated, .deleted), which all
+    // funnel through this function.
+    //
+    // The upsert returns representation, so the row id is already in hand — no extra
+    // round-trip. Terminal statuses clear the pointer instead of setting it; see
+    // isTerminalSubscriptionStatus for why that is not simply `!isEntitled`.
+    const subscriptionRowId = result.data?.[0]?.id;
+    const linkResult = await sb.update(
+      'organizations',
+      {
+        active_subscription_id: isTerminalSubscriptionStatus(status)
+          ? null
+          : (subscriptionRowId ?? null),
+      },
+      [{ column: 'id', operator: 'eq', value: orgId }],
+    );
+    return toVoidResult(linkResult);
   }
 
   /**


### PR DESCRIPTION
One commit, three files. Clean base — branched off `origin/main` after #20 merged, so the diff is exactly this fix.

> [!WARNING]
> **Already deployed to production.** `stripe-webhook` deploys manually, not via CI, so prod is running this code (`adbfc567-dad2-4004-aafa-09764b2150ed`, 2026-08-01T01:17Z) while `main` is not. Merging closes that gap. Rollback if needed: `wrangler rollback cdf60c9f-9e04-4ed8-90a5-26787f47dfef --name stripe-webhook`.

## The bug

`organizations.active_subscription_id` and its FK have existed since `20260320000000`, but **nothing had ever written the column** — not this Worker, not `api-gateway`, and no DB trigger. Verified two ways: grepping the whole `workers/` tree returned zero writers, and querying `pg_proc` for any function referencing the column returned none.

So the pointer sat permanently null even for paying organizations. Surfaced by `team-inventoryai-io`, which held a live `subscriptions` row and a null pointer after a real checkout completed. (`alyshia-ledlie` having one set was a red herring — set by hand or by a since-removed path, not by live code.)

## The fix

The write-back goes inside `upsertSubscription` rather than per-handler, because all three writers funnel through it — `checkout.session.completed`, `customer.subscription.updated`, and `.deleted`. One change, every path.

No extra round-trip: the upsert already requests `return=representation`, so the new row id is in hand. `SubscriptionUpsertRow` types `id` as optional inbound and present outbound, since inference from the inserted literal has no `id` at all.

## Why the terminal check is not `!isEntitled`

New `isTerminalSubscriptionStatus` in `workers/lib/billing.ts`, placed beside `isEntitled` because that file already argues for keeping these decisions in one place — and this is the same trap one level over:

```ts
export function isTerminalSubscriptionStatus(status: string): boolean {
  return status === 'canceled' || status === 'incomplete_expired';
}
```

`past_due`, `unpaid`, `paused` and `incomplete` are all **unentitled but still live** — they describe a subscription the org owns. Clearing the pointer on `!isEntitled` reads as obviously correct and would orphan it the moment a payment failed. Only `canceled` and `incomplete_expired` are states Stripe never transitions out of.

## Tests: 163 → 172

| | |
|---|---|
| pointer set to the upserted row id, with `id=eq.org-1` on the wire | ✓ |
| parameterized — survives all 5 non-terminal statuses | ✓ |
| parameterized — cleared for both terminal statuses | ✓ |
| failed org write-back propagates as `{ ok: false }`, not swallowed | ✓ |

These drive the **real** Supabase REST client over a stubbed fetch transport, so the wire format is asserted rather than a mocked client's behaviour.

The shared `subscriptionRoutes` helper needed a `PATCH organizations` route added — without it every case failed on the write-back instead of on what it meant to test. That's called out in a comment so the next person doesn't delete it as noise.

Full worker suite green: **208 + 188 + 29 + 172**. `lint:workers` (tsc ×7) clean — worth noting because `workers/lib/billing.ts` is shared across all seven workers.

## Production data

Existing rows were backfilled separately (not in this diff), guarded on two invariants inside a transaction: no org with a live subscription left mismatched, and no pointer resolving to a foreign or missing subscription row. Terminal subscriptions were excluded rather than pointed at, so backfilled rows are indistinguishable from what the Worker now writes.

```
alyshia-ledlie        → 6ae3a7ab  (trialing)
team-inventoryai-io   → 88ccd3ee  (active)
```

## Verification limits

End-to-end behaviour can't be confirmed without a real Stripe event — the deployed path only runs on `checkout.session.completed` or `customer.subscription.*`. Post-deploy probes confirm the Worker is healthy and routing (`GET /health` → 200, unsigned `POST /webhook` → 401 `Missing stripe-signature header`), but the next genuine subscription event is what will exercise the new write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
